### PR TITLE
Add `tus.handle()` support for `http.createServer()`

### DIFF
--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -15,7 +15,7 @@ class PostHandler extends BaseHandler {
     send(req, res) {
         return this.store.create(req)
             .then((File) => {
-                const url = `//${req.headers.host}${req.baseUrl || ''}${this.store.path}/${File.id}`;
+                const url = `//${req.headers.host}${req.baseUrl || req.url || ''}/${File.id}`;
                 this.emit(EVENT_ENDPOINT_CREATED, { url });
                 return super.send(res, 201, { Location: url });
             })


### PR DESCRIPTION
`req.baseUrl` is a property added by Express, fallback to `req.url` instead.

Also, we want to control the upload endpoint so we cannot rely on `this.store.path`.