### PR TITLE
Ask client to retry in case upload part is unreadable

### DIFF
--- a/lib/stores/s3Store.js
+++ b/lib/stores/s3Store.js
@@ -371,13 +371,20 @@ class S3Store extends DataStore {
      * @return {Promise<String>}                     which resolves with the parts' etag
      */
     _uploadPart(metadata, temp_file, current_part_number) {
+        const readStream = temp_file.createReadStream();
+
+        // no-op'ing as `readStream` errors will be thrown in the
+        // promise below when `this.client.uploadPart` tries
+        // to read from it
+        readStream.on('error', () => {});
+
         return this.client
             .uploadPart({
                 Bucket: this.bucket_name,
                 Key: metadata.file.id,
                 UploadId: metadata.upload_id,
                 PartNumber: current_part_number,
-                Body: temp_file.createReadStream(),
+                Body: readStream,
             })
             .promise()
             .then((data) => {
@@ -537,8 +544,14 @@ class S3Store extends DataStore {
                                 return resolve(current_offset.size);
                             })
                             .catch((err) => {
+                                if (err.code === 'ENOENT') {
+                                    console.warn(`[S3Store] unable to upload ${temp_file.path} as its`
+                                    + ' Stream is not readable. Asking client to upload it again...');
+                                    return resolve(offset);
+                                }
+
                                 console.error(err);
-                                reject(err);
+                                return reject(err);
                             });
                     });
 


### PR DESCRIPTION
It might happen that when S3 lib tries to read from the temp file stream, the file is not there anymore.
So now we handle those errors and send the previous `offset` to the client so it can gracefully re-upload the respective part.